### PR TITLE
feat: merge community PRs #8, #11, #12 with cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ sudo launchctl unload /Library/LaunchDaemons/com.taigrr.spank.plist
 1. Reads raw accelerometer data directly via IOKit HID (Apple SPU sensor)
 2. Runs vibration detection (STA/LTA, CUSUM, kurtosis, peak/MAD)
 3. When a significant impact is detected, plays an embedded MP3 response
-4. 500ms cooldown between responses to prevent rapid-fire
+4. 750ms cooldown between responses to prevent rapid-fire
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -36,15 +36,35 @@ sudo spank --sexy
 
 # Halo mode — plays Halo death sounds when slapped
 sudo spank --halo
+
+# Custom mode — plays your own MP3 files from a directory
+sudo spank --custom /path/to/mp3s
+
+# Adjust sensitivity with amplitude threshold (lower = more sensitive)
+sudo spank --min-amplitude 0.1   # more sensitive
+sudo spank --min-amplitude 0.25  # less sensitive
+sudo spank --sexy --min-amplitude 0.2
 ```
 
 ### Modes
 
 **Pain mode** (default): Randomly plays from 10 pain/protest audio clips when a slap is detected.
 
-**Sexy mode** (`--sexy`): Tracks slaps within a rolling 5-minute window. The more you slap, the more intense the audio response. 60 levels of escalation.
+**Sexy mode** (`--sexy`): Uses exponential decay scoring — intensity rises with rapid slaps and fades during pauses. 60 levels of escalation with an asymptotic curve that makes the top level nearly unreachable.
 
 **Halo mode** (`--halo`): Randomly plays from death sound effects from the Halo video game series when a slap is detected.
+
+**Custom mode** (`--custom`): Randomly plays MP3 files from a custom directory you specify.
+
+### Sensitivity
+
+Control detection sensitivity with `--min-amplitude` (default: 0.3):
+
+- Lower values (e.g., 0.05-0.10): Very sensitive, detects light taps
+- Medium values (e.g., 0.15-0.30): Balanced sensitivity
+- Higher values (e.g., 0.30-0.50): Only strong impacts trigger sounds
+
+The value represents the minimum acceleration amplitude (in g-force) required to trigger a sound.
 
 ## Running as a Service
 


### PR DESCRIPTION
Three-way merge of community contributions, cleaned up with a full CQL pass.

## Merged PRs
- **#8** (ZenAlexa): Fix sexy mode escalation — replaces hard 20-slap cap with exponential decay scoring using a 1-exp(-x) curve and 30s half-life
- **#11** (masterkusok): Add `--min-amplitude` flag for sensitivity control, replacing severity string matching with amplitude thresholds
- **#12** (criizx): Add `--custom` flag for user-provided MP3 directories with filesystem-based audio playback

## CQL Cleanup
- Extracted magic numbers into named constants (cooldown, poll interval, batch size, etc.)
- Early validation: empty audio directories now fail fast with a clear error
- Consolidated mutually exclusive mode check (`--sexy`/`--halo`/`--custom`)
- Extracted event loop into `listenForSlaps` for readability
- Flattened deeply nested conditionals with early continues
- Audio playback errors now surface to stderr instead of being silently dropped
- Fixed variable naming (`e` → `entry`, `s` → `sample`) per Go conventions
- Updated README with all new features and corrected sexy mode description
- All checks pass: `go vet`, `staticcheck`, `goimports`