### PR TITLE
feat: add --mic flag for microphone-based impact detection (M1 support)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ before:
 
 builds:
   - env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
       - GOPRIVATE=github.com/taigrr/apple-silicon-accelerometer
     goos:
       - darwin

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Uses the Apple Silicon accelerometer (Bosch BMI286 IMU via IOKit HID) to detect 
 
 ## Requirements
 
-- macOS on Apple Silicon (M2+)
-- `sudo` (for IOKit HID accelerometer access)
+- macOS on Apple Silicon
+  - **M2+**: Full accelerometer mode (default)
+  - **M1**: Use `--mic` flag (microphone-based detection)
+- `sudo` (for IOKit HID accelerometer access in default mode)
 
 ## Install
 
@@ -40,6 +42,11 @@ sudo spank --halo
 # Custom mode — plays your own MP3 files from a directory
 sudo spank --custom /path/to/mp3s
 
+# Mic mode — use microphone instead of accelerometer (works on M1!)
+sudo spank --mic
+sudo spank --mic --sexy
+sudo spank --mic --halo
+
 # Adjust sensitivity with amplitude threshold (lower = more sensitive)
 sudo spank --min-amplitude 0.1   # more sensitive
 sudo spank --min-amplitude 0.25  # less sensitive
@@ -64,7 +71,19 @@ Control detection sensitivity with `--min-amplitude` (default: 0.3):
 - Medium values (e.g., 0.15-0.30): Balanced sensitivity
 - Higher values (e.g., 0.30-0.50): Only strong impacts trigger sounds
 
-The value represents the minimum acceleration amplitude (in g-force) required to trigger a sound.
+The value represents the minimum acceleration amplitude (in g-force) or audio amplitude required to trigger a sound.
+
+### M1 Macs
+
+M1 MacBooks lack the Bosch BMI286 accelerometer found in M2+ models. Use the `--mic` flag to detect slaps via the built-in microphone instead:
+
+```bash
+sudo spank --mic
+```
+
+Mic mode detects sudden loud sounds (slaps, impacts) using audio analysis. It works with all audio modes (`--sexy`, `--halo`, `--custom`) and sensitivity tuning (`--min-amplitude`).
+
+> **Note:** If you run `spank` without `--mic` on an M1, it will print a helpful error message suggesting the `--mic` flag.
 
 ## Running as a Service
 
@@ -183,10 +202,19 @@ sudo launchctl unload /Library/LaunchDaemons/com.taigrr.spank.plist
 
 ## How it works
 
+### Accelerometer mode (default, M2+)
+
 1. Reads raw accelerometer data directly via IOKit HID (Apple SPU sensor)
 2. Runs vibration detection (STA/LTA, CUSUM, kurtosis, peak/MAD)
 3. When a significant impact is detected, plays an embedded MP3 response
 4. 750ms cooldown between responses to prevent rapid-fire
+
+### Mic mode (`--mic`, M1+)
+
+1. Captures audio from the built-in microphone via Core Audio (AudioQueue)
+2. Runs STA/LTA ratio analysis on RMS energy of each audio frame
+3. When a sudden loud sound is detected, plays an embedded MP3 response
+4. Same 750ms cooldown and amplitude thresholding as accelerometer mode
 
 ## Star History
 

--- a/main.go
+++ b/main.go
@@ -40,10 +40,12 @@ var sexyAudio embed.FS
 var haloAudio embed.FS
 
 var (
-	sexyMode     bool
-	haloMode     bool
-	customPath   string
-	minAmplitude float64
+	sexyMode        bool
+	haloMode        bool
+	customPath      string
+	minAmplitude    float64
+	micMode         bool
+	minAmplitudeSet bool // true if user explicitly passed --min-amplitude
 )
 
 // sensorReady is closed once shared memory is created and the sensor
@@ -189,6 +191,7 @@ within a minute, the more intense the sounds become.
 Use --halo to play random audio clips from Halo soundtracks on each slap.`,
 		Version: version,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			minAmplitudeSet = cmd.Flags().Changed("min-amplitude")
 			return run(cmd.Context())
 		},
 		SilenceUsage: true,
@@ -198,6 +201,7 @@ Use --halo to play random audio clips from Halo soundtracks on each slap.`,
 	cmd.Flags().BoolVarP(&haloMode, "halo", "H", false, "Enable halo mode")
 	cmd.Flags().StringVarP(&customPath, "custom", "c", "", "Path to custom MP3 audio directory")
 	cmd.Flags().Float64Var(&minAmplitude, "min-amplitude", 0.3, "Minimum amplitude threshold (0.0-1.0, lower = more sensitive)")
+	cmd.Flags().BoolVarP(&micMode, "mic", "m", false, "Use microphone for impact detection (works on M1+ Macs)")
 
 	if err := fang.Execute(context.Background(), cmd); err != nil {
 		os.Exit(1)
@@ -246,9 +250,21 @@ func run(ctx context.Context) error {
 	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
+	// Microphone mode: skip accelerometer entirely.
+	if micMode {
+		// Mic mode needs much lower min-amplitude since laptop slaps
+		// produce quiet thuds. Use 0.05 unless user explicitly set it.
+		if !minAmplitudeSet {
+			minAmplitude = 0.05
+		}
+		return runMicMode(ctx, pack)
+	}
+
 	// Create shared memory for accelerometer data.
 	accelRing, err := shm.CreateRing(shm.NameAccel)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "spank: failed to create accel shm: %v\n", err)
+		fmt.Fprintf(os.Stderr, "spank: tip: if you're on an M1 Mac, try: sudo spank --mic\n")
 		return fmt.Errorf("creating accel shm: %w", err)
 	}
 	defer accelRing.Close()
@@ -271,6 +287,7 @@ func run(ctx context.Context) error {
 	select {
 	case <-sensorReady:
 	case err := <-sensorErr:
+		fmt.Fprintf(os.Stderr, "spank: tip: if you're on an M1 Mac, try: sudo spank --mic\n")
 		return fmt.Errorf("sensor worker failed: %w", err)
 	case <-ctx.Done():
 		return nil
@@ -389,4 +406,76 @@ func playAudio(pack *soundPack, path string, speakerInit *bool) {
 		done <- true
 	})))
 	<-done
+}
+
+// runMicMode starts microphone-based impact detection.
+func runMicMode(ctx context.Context, pack *soundPack) error {
+	mic, err := NewMicCapture()
+	if err != nil {
+		return fmt.Errorf("mic mode: %w", err)
+	}
+	defer mic.Close()
+
+	// Small delay for mic to start producing data.
+	time.Sleep(200 * time.Millisecond)
+
+	return listenForSlapsFromMic(ctx, pack, mic)
+}
+
+// listenForSlapsFromMic polls the microphone and uses audio-based impact
+// detection, feeding events into the same slapTracker/playAudio pipeline.
+func listenForSlapsFromMic(ctx context.Context, pack *soundPack, mic *MicCapture) error {
+	tracker := newSlapTracker(pack)
+	speakerInit := false
+	micDet := NewMicDetector()
+	var lastYell time.Time
+
+	fmt.Printf("spank: listening for slaps in %s mode (mic)... (ctrl+c to quit)\n", pack.name)
+
+	ticker := time.NewTicker(sensorPollInterval)
+	defer ticker.Stop()
+
+	// Accumulate samples into frames
+	frameBuf := make([]float32, 0, micFrameSize)
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("\nbye!")
+			return nil
+		case <-ticker.C:
+		}
+
+		samples := mic.ReadNew()
+		if len(samples) == 0 {
+			continue
+		}
+
+		frameBuf = append(frameBuf, samples...)
+
+		// Process complete frames
+		for len(frameBuf) >= micFrameSize {
+			frame := frameBuf[:micFrameSize]
+			frameBuf = frameBuf[micFrameSize:]
+
+			ev := micDet.ProcessFrame(frame)
+			if ev == nil {
+				continue
+			}
+
+			now := time.Now()
+			if now.Sub(lastYell) <= slapCooldown {
+				continue
+			}
+			if ev.Amplitude < minAmplitude {
+				continue
+			}
+
+			lastYell = now
+			num, score := tracker.record(now)
+			file := tracker.getFile(score)
+			fmt.Printf("slap #%d [%s amp=%.5f] -> %s\n", num, ev.Severity, ev.Amplitude, file)
+			go playAudio(pack, file, &speakerInit)
+		}
+	}
 }

--- a/mic.go
+++ b/mic.go
@@ -1,0 +1,145 @@
+// mic.go provides microphone-based impact detection as an alternative to
+// the accelerometer. This enables spank to work on M1 Macs (and any Mac)
+// by detecting slap sounds through the built-in microphone.
+//
+// Uses macOS Core Audio (Audio Queue Services) via CGo.
+package main
+
+/*
+#cgo LDFLAGS: -framework AudioToolbox -framework CoreFoundation
+#include <AudioToolbox/AudioToolbox.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Ring buffer for audio samples shared between callback and Go.
+// Lock-free single-producer (callback) single-consumer (Go) ring.
+#define MIC_RING_SIZE 32768
+
+static float micRing[MIC_RING_SIZE];
+static volatile int64_t micWriteIdx = 0;
+
+static void micCallback(
+    void *inUserData,
+    AudioQueueRef inAQ,
+    AudioQueueBufferRef inBuffer,
+    const AudioTimeStamp *inStartTime,
+    UInt32 inNumPackets,
+    const AudioStreamPacketDescription *inPacketDesc)
+{
+    int16_t *samples = (int16_t *)inBuffer->mAudioData;
+    UInt32 count = inBuffer->mAudioDataByteSize / sizeof(int16_t);
+
+    for (UInt32 i = 0; i < count; i++) {
+        int64_t idx = __sync_fetch_and_add(&micWriteIdx, 1);
+        micRing[idx % MIC_RING_SIZE] = (float)samples[i] / 32768.0f;
+    }
+
+    AudioQueueEnqueueBuffer(inAQ, inBuffer, 0, NULL);
+}
+
+// startMicCapture opens the default input device and begins recording.
+// Returns 0 on success, non-zero on failure.
+static int startMicCapture(AudioQueueRef *outQueue) {
+    AudioStreamBasicDescription fmt;
+    memset(&fmt, 0, sizeof(fmt));
+    fmt.mSampleRate       = 44100.0;
+    fmt.mFormatID         = kAudioFormatLinearPCM;
+    fmt.mFormatFlags      = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked;
+    fmt.mBitsPerChannel   = 16;
+    fmt.mChannelsPerFrame = 1;
+    fmt.mFramesPerPacket  = 1;
+    fmt.mBytesPerFrame    = 2;
+    fmt.mBytesPerPacket   = 2;
+
+    OSStatus status = AudioQueueNewInput(
+        &fmt,
+        micCallback,
+        NULL,
+        NULL,           // run loop (NULL = internal)
+        NULL,           // run loop mode
+        0,              // flags
+        outQueue
+    );
+    if (status != 0) return (int)status;
+
+    // Allocate 3 buffers of 1024 samples each (~23ms at 44.1kHz)
+    for (int i = 0; i < 3; i++) {
+        AudioQueueBufferRef buf;
+        status = AudioQueueAllocateBuffer(*outQueue, 1024 * 2, &buf);
+        if (status != 0) return (int)status;
+        status = AudioQueueEnqueueBuffer(*outQueue, buf, 0, NULL);
+        if (status != 0) return (int)status;
+    }
+
+    status = AudioQueueStart(*outQueue, NULL);
+    return (int)status;
+}
+
+static void stopMicCapture(AudioQueueRef queue) {
+    AudioQueueStop(queue, true);
+    AudioQueueDispose(queue, true);
+}
+
+static int64_t getMicWriteIdx() {
+    return micWriteIdx;
+}
+
+static float getMicSample(int64_t idx) {
+    return micRing[idx % MIC_RING_SIZE];
+}
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+const micRingSize = C.MIC_RING_SIZE
+
+// MicCapture manages microphone recording via Core Audio.
+type MicCapture struct {
+	queue    C.AudioQueueRef
+	lastRead int64
+}
+
+// NewMicCapture creates and starts microphone capture.
+func NewMicCapture() (*MicCapture, error) {
+	var queue C.AudioQueueRef
+	ret := C.startMicCapture(&queue)
+	if ret != 0 {
+		return nil, fmt.Errorf("failed to start mic capture (Core Audio error %d); check microphone permissions in System Settings > Privacy > Microphone", ret)
+	}
+	mc := &MicCapture{
+		queue:    queue,
+		lastRead: int64(C.getMicWriteIdx()),
+	}
+	return mc, nil
+}
+
+// ReadNew returns new audio samples since the last call.
+// Samples are float32 in [-1.0, 1.0].
+func (mc *MicCapture) ReadNew() []float32 {
+	writeIdx := int64(C.getMicWriteIdx())
+	avail := writeIdx - mc.lastRead
+	if avail <= 0 {
+		return nil
+	}
+	if avail > micRingSize {
+		// Overrun — skip to latest data
+		mc.lastRead = writeIdx - micRingSize/2
+		avail = writeIdx - mc.lastRead
+	}
+
+	samples := make([]float32, avail)
+	for i := int64(0); i < avail; i++ {
+		samples[i] = float32(C.getMicSample(C.int64_t(mc.lastRead + i)))
+	}
+	mc.lastRead = writeIdx
+	return samples
+}
+
+// Close stops and releases the mic capture resources.
+func (mc *MicCapture) Close() {
+	C.stopMicCapture(mc.queue)
+	mc.queue = (C.AudioQueueRef)(unsafe.Pointer(nil))
+}

--- a/mic_detector.go
+++ b/mic_detector.go
@@ -1,0 +1,157 @@
+// mic_detector.go implements audio-based impact detection for microphone mode.
+// Uses STA/LTA ratio on RMS amplitude to detect sudden sounds (slaps,
+// impacts, taps) while adapting to background noise.
+//
+// A laptop slap produces a low-level thud that is much quieter than a hand
+// clap. To handle this, we use the STA/LTA *ratio* as the primary signal
+// (detecting sudden changes relative to background) rather than requiring
+// high absolute loudness.
+package main
+
+import (
+	"math"
+	"time"
+
+	"github.com/taigrr/apple-silicon-accelerometer/detector"
+)
+
+const (
+	// micSampleRate matches the Core Audio capture rate.
+	micSampleRate = 44100
+
+	// micFrameSize is the number of samples per analysis frame (~23ms).
+	micFrameSize = 1024
+
+	// micSTAFrames is the short-term average window in frames (~46ms).
+	micSTAFrames = 2
+
+	// micLTAFrames is the long-term average window in frames (~1.6s).
+	micLTAFrames = 70
+
+	// micSTALTAThreshold is the STA/LTA ratio that triggers an event.
+	// Lower = more sensitive. A laptop slap typically produces a ratio
+	// of 2-4, while a hand clap produces 10+.
+	micSTALTAThreshold = 1.8
+
+	// micMinEventGap prevents duplicate detections within this duration.
+	micMinEventGap = 50 * time.Millisecond
+
+	// micWarmupFrames is the number of frames before detection starts.
+	// Shorter warmup means faster startup but slightly noisier initial LTA.
+	micWarmupFrames = 30
+)
+
+// MicDetector analyzes audio frames to detect impact events.
+type MicDetector struct {
+	sta       float64
+	lta       float64
+	staAlpha  float64
+	ltaAlpha  float64
+	peakRMS   float64 // tracks recent peak for amplitude normalization
+	ready     bool
+	warmup    int
+	lastEvent time.Time
+}
+
+// NewMicDetector creates a new audio impact detector.
+func NewMicDetector() *MicDetector {
+	return &MicDetector{
+		staAlpha: 1.0 / float64(micSTAFrames),
+		ltaAlpha: 1.0 / float64(micLTAFrames),
+	}
+}
+
+// ProcessFrame analyzes a frame of audio samples and returns a
+// detector.Event if an impact is detected, or nil otherwise.
+// Samples should be float32 in [-1.0, 1.0].
+func (md *MicDetector) ProcessFrame(samples []float32) *detector.Event {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	// Calculate RMS energy for this frame
+	var sumSq float64
+	var peak float64
+	for _, s := range samples {
+		v := float64(s)
+		sumSq += v * v
+		if abs := math.Abs(v); abs > peak {
+			peak = abs
+		}
+	}
+	rms := math.Sqrt(sumSq / float64(len(samples)))
+
+	// Track peak RMS with slow decay for amplitude normalization
+	if rms > md.peakRMS {
+		md.peakRMS = rms
+	} else {
+		md.peakRMS *= 0.999 // slow decay
+	}
+
+	// Exponential moving average for STA and LTA
+	energy := rms * rms
+	if !md.ready {
+		md.sta = energy
+		md.lta = energy
+		md.ready = true
+		md.warmup = 0
+		return nil
+	}
+
+	md.sta += md.staAlpha * (energy - md.sta)
+	md.lta += md.ltaAlpha * (energy - md.lta)
+
+	// Need warmup period for LTA to stabilize
+	md.warmup++
+	if md.warmup < micWarmupFrames {
+		return nil
+	}
+
+	// STA/LTA ratio — this is the key metric.
+	// It measures how much the current energy exceeds the background,
+	// so even a quiet laptop thud will spike the ratio if the room is quiet.
+	ratio := md.sta / (md.lta + 1e-30)
+
+	now := time.Now()
+
+	// Check for impact
+	if ratio > micSTALTAThreshold && now.Sub(md.lastEvent) > micMinEventGap {
+		md.lastEvent = now
+
+		// Use the ratio itself to derive amplitude, not just raw RMS.
+		// This way a laptop slap in a quiet room gives a similar amplitude
+		// to a clap in a noisy room — both represent "sudden change".
+		// Map ratio to 0-1: ratio of 1.8 → ~0.05, ratio of 20 → ~1.0
+		ratioAmp := math.Min(1.0, (ratio-1.0)/15.0)
+
+		// Also factor in absolute RMS scaled up aggressively
+		rmsAmp := math.Min(1.0, rms*20.0)
+
+		// Combined amplitude: primarily ratio-driven, boosted by RMS
+		amplitude := math.Max(ratioAmp, rmsAmp)
+
+		// Classify severity based on ratio strength
+		var severity string
+		switch {
+		case ratio > 10.0:
+			severity = "CHOC_MAJEUR"
+		case ratio > 5.0:
+			severity = "CHOC_MOYEN"
+		case ratio > 2.5:
+			severity = "MICRO_CHOC"
+		default:
+			severity = "VIBRATION"
+		}
+
+		return &detector.Event{
+			Time:      now,
+			Severity:  severity,
+			Symbol:    "★",
+			Label:     "mic-impact",
+			Amplitude: amplitude,
+			Sources:   []string{"MIC_STA_LTA"},
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

M1 MacBooks lack the Bosch BMI286 accelerometer found in M2+ models. This PR adds a --mic flag that uses the built-in microphone via Core Audio to detect slap sounds instead, enabling spank to work on all Apple Silicon Macs (M1, M2, M3, M4).

## Changes

### New files
- mic.go — Core Audio microphone capture via CGo (AudioQueue Services, 44.1kHz mono, 16-bit PCM, lock-free ring buffer)
- mic_detector.go — STA/LTA ratio-based audio impact detector that emits detector.Event structs compatible with the existing pipeline

### Modified files
- main.go — Added --mic flag, runMicMode(), listenForSlapsFromMic(), auto-lowered min-amplitude default for mic mode (0.05 vs 0.3), and helpful fallback message when accelerometer fails on M1
- README.md — Updated requirements, added M1/mic mode documentation and usage examples
- .goreleaser.yaml — Changed CGO_ENABLED=0 → CGO_ENABLED=1 for Core Audio bindings

## How it works

1. Captures audio from the default input device via Core Audio AudioQueue Services
2. Computes RMS energy per frame (1024 samples, ~23ms)
3. Runs STA/LTA ratio analysis — detects sudden energy spikes relative to background noise
4. Uses the ratio itself (not just raw loudness) to derive amplitude, so quiet laptop thuds register even in quiet environments
5. Feeds events into the existing slapTracker / playAudio pipeline — works with all modes (--sexy, --halo, --custom)

## Usage

sudo spank --mic              # pain mode with mic
sudo spank --mic --sexy       # sexy mode with mic  
sudo spank --mic --halo       # halo mode with mic
sudo spank --mic --min-amplitude 0.02  # extra sensitive

## Testing

Tested on M1 MacBook Pro — reliably detects laptop slaps, desk thumps, and hand claps across all audio modes. Sensitivity tunable via --min-amplitude.

## Notes

- The --mic mode introduces CGo (for Core Audio AudioQueue bindings). The rest of the codebase remains zero-CGO via purego.
- First run prompts for microphone permission via macOS TCC.
- --mic is compatible with all existing flags (--sexy, --halo, --custom, --min-amplitude).