### PR TITLE
added extra note mentioned in description as without it when i run su…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Or build from source:
 go install github.com/taigrr/spank@latest
 ```
 
-> **Note:** `go install` places the binary in `~/go/bin`, which `sudo` can't find by default. Copy it to a system path so `sudo spank` works:
+> **Note:** `go install` places the binary in `$GOBIN` (if set) or `$(go env GOPATH)/bin` (which defaults to `~/go/bin`). Copy it to a system path so `sudo spank` works. For example, with the default Go settings:
 > ```bash
-> sudo cp ~/go/bin/spank /usr/local/bin/spank
+> sudo cp "$(go env GOPATH)/bin/spank" /usr/local/bin/spank
 > ```
 
 ## Usage


### PR DESCRIPTION
…do spank it returns as spank : command not found

> **Note:** `go install` places the binary in `~/go/bin`, which `sudo` can't find by default. Copy it to a system path so `sudo spank` works:
> ```bash
> sudo cp ~/go/bin/spank /usr/local/bin/spank
> ```