### PR TITLE
feat(audio): scale volume by slap amplitude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist/
 *.log
 .crush
+spank.test

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Uses the Apple Silicon accelerometer (Bosch BMI286 IMU via IOKit HID) to detect 
 
 - macOS on Apple Silicon (M2+)
 - `sudo` (for IOKit HID accelerometer access)
+- Go 1.26+ (if building from source)
 
 ## Install
 
@@ -204,7 +205,8 @@ sudo launchctl unload /Library/LaunchDaemons/com.taigrr.spank.plist
 1. Reads raw accelerometer data directly via IOKit HID (Apple SPU sensor)
 2. Runs vibration detection (STA/LTA, CUSUM, kurtosis, peak/MAD)
 3. When a significant impact is detected, plays an embedded MP3 response
-4. 750ms cooldown between responses to prevent rapid-fire, adjustable with `--cooldown`
+4. **Volume scales with impact force** — light taps play quietly, hard slaps play at full volume
+5. 750ms cooldown between responses to prevent rapid-fire, adjustable with `--cooldown`
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ sudo launchctl unload /Library/LaunchDaemons/com.taigrr.spank.plist
 1. Reads raw accelerometer data directly via IOKit HID (Apple SPU sensor)
 2. Runs vibration detection (STA/LTA, CUSUM, kurtosis, peak/MAD)
 3. When a significant impact is detected, plays an embedded MP3 response
-4. **Volume scales with impact force** — light taps play quietly, hard slaps play at full volume
+4. **Optional volume scaling** (`--volume-scaling`) — light taps play quietly, hard slaps play at full volume
 5. 750ms cooldown between responses to prevent rapid-fire, adjustable with `--cooldown`
 
 ## Star History

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,9 @@ require (
 require (
 	charm.land/lipgloss/v2 v2.0.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260223171050-89c142e4aa73 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260303162955-0b88c25f3fff // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
-	github.com/charmbracelet/x/exp/charmtone v0.0.0-20260301212224-50d5c240f29a // indirect
+	github.com/charmbracelet/x/exp/charmtone v0.0.0-20260305213658-fe36e8c10185 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,12 +6,12 @@ github.com/charmbracelet/colorprofile v0.4.2 h1:BdSNuMjRbotnxHSfxy+PCSa4xAmz7szw
 github.com/charmbracelet/colorprofile v0.4.2/go.mod h1:0rTi81QpwDElInthtrQ6Ni7cG0sDtwAd4C4le060fT8=
 github.com/charmbracelet/fang v0.4.4 h1:G4qKxF6or/eTPgmAolwPuRNyuci3hTUGGX1rj1YkHJY=
 github.com/charmbracelet/fang v0.4.4/go.mod h1:P5/DNb9DddQ0Z0dbc0P3ol4/ix5Po7Ofr2KMBfAqoCo=
-github.com/charmbracelet/ultraviolet v0.0.0-20260223171050-89c142e4aa73 h1:Af/L28Xh+pddhouT/6lJ7IAIYfu5tWJOB0iqt+mXsYM=
-github.com/charmbracelet/ultraviolet v0.0.0-20260223171050-89c142e4aa73/go.mod h1:E6/0abq9uG2SnM8IbLB9Y5SW09uIgfaFETk8aRzgXUQ=
+github.com/charmbracelet/ultraviolet v0.0.0-20260303162955-0b88c25f3fff h1:uY7A6hTokHPJBHfq7rj9Y/wm+IAjOghZTxKfVW6QLvw=
+github.com/charmbracelet/ultraviolet v0.0.0-20260303162955-0b88c25f3fff/go.mod h1:E6/0abq9uG2SnM8IbLB9Y5SW09uIgfaFETk8aRzgXUQ=
 github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF7ihZW8=
 github.com/charmbracelet/x/ansi v0.11.6/go.mod h1:2JNYLgQUsyqaiLovhU2Rv/pb8r6ydXKS3NIttu3VGZQ=
-github.com/charmbracelet/x/exp/charmtone v0.0.0-20260301212224-50d5c240f29a h1:KIR1S/dEZjiV6yGTWXwR7ewBonvN0sA62LeIU4YyZng=
-github.com/charmbracelet/x/exp/charmtone v0.0.0-20260301212224-50d5c240f29a/go.mod h1:nsExn0DGyX0lh9LwLHTn2Gg+hafdzfSXnC+QmEJTZFY=
+github.com/charmbracelet/x/exp/charmtone v0.0.0-20260305213658-fe36e8c10185 h1:/192monmpmRICpSPrFRzkIO+xfhioV6/nwrQdkDTj10=
+github.com/charmbracelet/x/exp/charmtone v0.0.0-20260305213658-fe36e8c10185/go.mod h1:nsExn0DGyX0lh9LwLHTn2Gg+hafdzfSXnC+QmEJTZFY=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f/go.mod h1:IfZAMTHB6XkZSeXUqriemErjAWCCzT0LwjKFYCZyw0I=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=

--- a/main.go
+++ b/main.go
@@ -51,9 +51,10 @@ var (
 	fastMode     bool
 	minAmplitude float64
 	cooldownMs   int
-	stdioMode    bool
-	paused       bool
-	pausedMu     sync.RWMutex
+	stdioMode      bool
+	volumeScaling  bool
+	paused         bool
+	pausedMu       sync.RWMutex
 )
 
 // sensorReady is closed once shared memory is created and the sensor
@@ -254,6 +255,7 @@ Use --halo to play random audio clips from Halo soundtracks on each slap.`,
 	cmd.Flags().Float64Var(&minAmplitude, "min-amplitude", defaultMinAmplitude, "Minimum amplitude threshold (0.0-1.0, lower = more sensitive)")
 	cmd.Flags().IntVar(&cooldownMs, "cooldown", defaultCooldownMs, "Cooldown between responses in milliseconds")
 	cmd.Flags().BoolVar(&stdioMode, "stdio", false, "Enable stdio mode: JSON output and stdin commands (for GUI integration)")
+	cmd.Flags().BoolVar(&volumeScaling, "volume-scaling", false, "Scale playback volume by slap amplitude (harder hits = louder)")
 
 	if err := fang.Execute(context.Background(), cmd); err != nil {
 		os.Exit(1)
@@ -523,16 +525,19 @@ func playAudio(pack *soundPack, path string, amplitude float64, speakerInit *boo
 	}
 	speakerMu.Unlock()
 
-	// Scale volume based on slap amplitude
-	vol := &effects.Volume{
-		Streamer: streamer,
-		Base:     2,
-		Volume:   amplitudeToVolume(amplitude),
-		Silent:   false,
+	// Optionally scale volume based on slap amplitude
+	var source beep.Streamer = streamer
+	if volumeScaling {
+		source = &effects.Volume{
+			Streamer: streamer,
+			Base:     2,
+			Volume:   amplitudeToVolume(amplitude),
+			Silent:   false,
+		}
 	}
 
 	done := make(chan bool)
-	speaker.Play(beep.Seq(vol, beep.Callback(func() {
+	speaker.Play(beep.Seq(source, beep.Callback(func() {
 		done <- true
 	})))
 	<-done
@@ -593,12 +598,17 @@ func processCommands(r io.Reader, w io.Writer) {
 			if stdioMode {
 				fmt.Fprintf(w, `{"status":"settings_updated","amplitude":%.4f,"cooldown":%d}%s`, minAmplitude, cooldownMs, "\n")
 			}
+		case "volume-scaling":
+			volumeScaling = !volumeScaling
+			if stdioMode {
+				fmt.Fprintf(w, `{"status":"volume_scaling_toggled","volume_scaling":%t}%s`, volumeScaling, "\n")
+			}
 		case "status":
 			pausedMu.RLock()
 			isPaused := paused
 			pausedMu.RUnlock()
 			if stdioMode {
-				fmt.Fprintf(w, `{"status":"ok","paused":%t,"amplitude":%.4f,"cooldown":%d}%s`, isPaused, minAmplitude, cooldownMs, "\n")
+				fmt.Fprintf(w, `{"status":"ok","paused":%t,"amplitude":%.4f,"cooldown":%d,"volume_scaling":%t}%s`, isPaused, minAmplitude, cooldownMs, volumeScaling, "\n")
 			}
 		default:
 			if stdioMode {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/charmbracelet/fang"
 	"github.com/gopxl/beep/v2"
+	"github.com/gopxl/beep/v2/effects"
 	"github.com/gopxl/beep/v2/mp3"
 	"github.com/gopxl/beep/v2/speaker"
 	"github.com/spf13/cobra"
@@ -446,13 +447,46 @@ func listenForSlaps(ctx context.Context, pack *soundPack, accelRing *shm.RingBuf
 		} else {
 			fmt.Printf("slap #%d [%s amp=%.5fg] -> %s\n", num, ev.Severity, ev.Amplitude, file)
 		}
-		go playAudio(pack, file, &speakerInit)
+		go playAudio(pack, file, ev.Amplitude, &speakerInit)
 	}
 }
 
 var speakerMu sync.Mutex
 
-func playAudio(pack *soundPack, path string, speakerInit *bool) {
+// amplitudeToVolume maps a detected amplitude to a beep/effects.Volume
+// level. Amplitude typically ranges from ~0.05 (light tap) to ~1.0+
+// (hard slap). The mapping uses a logarithmic curve so that light taps
+// are noticeably quieter and hard hits play near full volume.
+//
+// Returns a value in the range [-3.0, 0.0] for use with effects.Volume
+// (base 2): -3.0 is ~1/8 volume, 0.0 is full volume.
+func amplitudeToVolume(amplitude float64) float64 {
+	const (
+		minAmp   = 0.05  // softest detectable
+		maxAmp   = 0.80  // treat anything above this as max
+		minVol   = -3.0  // quietest playback (1/8 volume with base 2)
+		maxVol   = 0.0   // full volume
+	)
+
+	// Clamp
+	if amplitude <= minAmp {
+		return minVol
+	}
+	if amplitude >= maxAmp {
+		return maxVol
+	}
+
+	// Normalize to [0, 1]
+	t := (amplitude - minAmp) / (maxAmp - minAmp)
+
+	// Log curve for more natural volume scaling
+	// log(1 + t*99) / log(100) maps [0,1] -> [0,1] with a log curve
+	t = math.Log(1+t*99) / math.Log(100)
+
+	return minVol + t*(maxVol-minVol)
+}
+
+func playAudio(pack *soundPack, path string, amplitude float64, speakerInit *bool) {
 	var streamer beep.StreamSeekCloser
 	var format beep.Format
 
@@ -489,8 +523,16 @@ func playAudio(pack *soundPack, path string, speakerInit *bool) {
 	}
 	speakerMu.Unlock()
 
+	// Scale volume based on slap amplitude
+	vol := &effects.Volume{
+		Streamer: streamer,
+		Base:     2,
+		Volume:   amplitudeToVolume(amplitude),
+		Silent:   false,
+	}
+
 	done := make(chan bool)
-	speaker.Play(beep.Seq(streamer, beep.Callback(func() {
+	speaker.Play(beep.Seq(vol, beep.Callback(func() {
 		done <- true
 	})))
 	<-done

--- a/stdin_test.go
+++ b/stdin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 )
@@ -335,6 +336,51 @@ func TestMultipleCommands(t *testing.T) {
 	json.Unmarshal([]byte(lines[3]), &resp4)
 	if resp4.Paused {
 		t.Error("line 4: expected paused=false")
+	}
+}
+
+func TestAmplitudeToVolume(t *testing.T) {
+	tests := []struct {
+		name      string
+		amplitude float64
+		wantMin   float64
+		wantMax   float64
+	}{
+		{"below minimum returns min volume", 0.01, -3.0, -3.0},
+		{"at minimum returns min volume", 0.05, -3.0, -3.0},
+		{"above maximum returns max volume", 1.0, 0.0, 0.0},
+		{"at maximum returns max volume", 0.80, 0.0, 0.0},
+		{"mid amplitude returns mid-range", 0.40, -2.0, -0.5},
+		{"low amplitude is quieter than high", 0.10, -3.0, -1.5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := amplitudeToVolume(tt.amplitude)
+			if got < tt.wantMin || got > tt.wantMax {
+				t.Errorf("amplitudeToVolume(%f) = %f, want in [%f, %f]",
+					tt.amplitude, got, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+
+	// Monotonicity: higher amplitude should yield higher (or equal) volume
+	prev := amplitudeToVolume(0.05)
+	for amp := 0.10; amp <= 0.80; amp += 0.05 {
+		cur := amplitudeToVolume(amp)
+		if cur < prev-1e-9 {
+			t.Errorf("non-monotonic: amplitudeToVolume(%f)=%f < amplitudeToVolume(prev)=%f",
+				amp, cur, prev)
+		}
+		prev = cur
+	}
+
+	// Verify no NaN or Inf
+	for _, amp := range []float64{0, 0.05, 0.1, 0.5, 0.8, 1.0, 10.0} {
+		v := amplitudeToVolume(amp)
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			t.Errorf("amplitudeToVolume(%f) returned %f", amp, v)
+		}
 	}
 }
 

--- a/stdin_test.go
+++ b/stdin_test.go
@@ -16,6 +16,7 @@ func resetGlobals() {
 	minAmplitude = 0.05
 	cooldownMs = 750
 	stdioMode = true
+	volumeScaling = false
 }
 
 func TestPauseCommand(t *testing.T) {
@@ -179,6 +180,41 @@ func TestSetAmplitudeOutOfRange(t *testing.T) {
 	}
 }
 
+func TestVolumeScalingCommand(t *testing.T) {
+	resetGlobals()
+
+	// Toggle on
+	input := `{"cmd":"volume-scaling"}` + "\n"
+	var output bytes.Buffer
+	processCommands(strings.NewReader(input), &output)
+
+	if !volumeScaling {
+		t.Error("expected volumeScaling to be true after toggle")
+	}
+
+	var resp struct {
+		Status        string `json:"status"`
+		VolumeScaling bool   `json:"volume_scaling"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Status != "volume_scaling_toggled" {
+		t.Errorf("expected status 'volume_scaling_toggled', got %q", resp.Status)
+	}
+	if !resp.VolumeScaling {
+		t.Error("expected volume_scaling true in response")
+	}
+
+	// Toggle off
+	output.Reset()
+	processCommands(strings.NewReader(input), &output)
+
+	if volumeScaling {
+		t.Error("expected volumeScaling to be false after second toggle")
+	}
+}
+
 func TestStatusCommand(t *testing.T) {
 	resetGlobals()
 	minAmplitude = 0.1
@@ -190,10 +226,11 @@ func TestStatusCommand(t *testing.T) {
 	processCommands(strings.NewReader(input), &output)
 
 	var resp struct {
-		Status    string  `json:"status"`
-		Paused    bool    `json:"paused"`
-		Amplitude float64 `json:"amplitude"`
-		Cooldown  int     `json:"cooldown"`
+		Status        string  `json:"status"`
+		Paused        bool    `json:"paused"`
+		Amplitude     float64 `json:"amplitude"`
+		Cooldown      int     `json:"cooldown"`
+		VolumeScaling bool    `json:"volume_scaling"`
 	}
 	if err := json.Unmarshal(output.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
@@ -209,6 +246,9 @@ func TestStatusCommand(t *testing.T) {
 	}
 	if resp.Cooldown != 600 {
 		t.Errorf("expected cooldown 600, got %d", resp.Cooldown)
+	}
+	if resp.VolumeScaling != false {
+		t.Errorf("expected volume_scaling false, got %t", resp.VolumeScaling)
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Volume scaling by amplitude** — harder slaps play louder, light taps play quietly. Uses a logarithmic curve mapping detected acceleration (0.05g–0.8g) to playback volume via `beep/effects.Volume`. Closes #32.
- **Dependency updates** — bumped `charmbracelet/ultraviolet` and `charmbracelet/x/exp/charmtone` to latest.
- **README** — added Go 1.26+ build requirement, documented volume scaling in "How it works" section.

## Implementation

`amplitudeToVolume()` maps amplitude to a `[-3.0, 0.0]` range (base 2 exponentiation):
- `-3.0` = 1/8 volume (lightest detectable tap)
- `0.0` = full volume (hard slap)

The log curve (`log(1 + t*99) / log(100)`) ensures perceived volume scales naturally — you hear a noticeable difference between a tap and a smack without soft hits being silent.

## Testing

- Cross-compiled for darwin/arm64 (build passes)
- Added unit tests for `amplitudeToVolume`: boundary values, monotonicity, and NaN/Inf safety
- Existing stdin command tests unaffected