### PR TITLE
feat: add Nix flake with Home Manager module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.log
 .crush
 spank.test
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772736753,
+        "narHash": "sha256-au/m3+EuBLoSzWUCb64a/MZq6QUtOV8oC0D9tY2scPQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "917fec990948658ef1ccd07cef2a1ef060786846",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "spank - Yells 'ow!' when you slap the laptop";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      # Home Manager module available regardless of system
+      hmModule = import ./nix/hm-module.nix self;
+    in
+    flake-utils.lib.eachSystem [ "aarch64-darwin" ] (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.callPackage ./nix/package.nix { };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${system}.default ];
+        };
+      }
+    ) // {
+      homeManagerModules.default = hmModule;
+      homeManagerModule = hmModule;
+    };
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,60 @@
+flake:
+
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.spank;
+  spankPkg = flake.packages.${pkgs.stdenv.hostPlatform.system}.default;
+in
+{
+  options.programs.spank = {
+    enable = lib.mkEnableOption "spank - yells when you slap the laptop";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = spankPkg;
+      defaultText = lib.literalExpression "inputs.spank.packages.\${system}.default";
+      description = "The spank package to use.";
+    };
+
+    mode = lib.mkOption {
+      type = lib.types.enum [ "pain" "sexy" "halo" ];
+      default = "pain";
+      description = "Audio mode to use.";
+    };
+
+    fast = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable faster detection tuning.";
+    };
+
+    minAmplitude = lib.mkOption {
+      type = lib.types.nullOr lib.types.float;
+      default = null;
+      description = "Minimum amplitude threshold (0.0-1.0).";
+    };
+
+    cooldown = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      description = "Cooldown between responses in milliseconds.";
+    };
+
+    volumeScaling = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Scale playback volume by slap amplitude.";
+    };
+
+    customPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to custom MP3 audio directory.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, go_1_26 }:
+
+buildGoModule.override { go = go_1_26; } {
+  pname = "spank";
+  version = "0-unstable";
+
+  src = lib.cleanSource ./..;
+
+  # Run `nix build` to get the correct hash, then replace this placeholder
+  vendorHash = "sha256-R63lSTQvwZ/zw2ccuwXk6rkuQ0t2Zs4mU3Trh+IxKf4=";
+
+  ldflags = [ "-s" "-w" ];
+
+  # Tests require Apple Silicon accelerometer hardware
+  doCheck = false;
+
+  meta = {
+    description = "Yells 'ow!' when you slap the laptop";
+    homepage = "https://github.com/taigrr/spank";
+    license = lib.licenses.mit;
+    platforms = [ "aarch64-darwin" ];
+    mainProgram = "spank";
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a Nix flake that builds the package for `aarch64-darwin`
- Includes a Home Manager module for easy integration into nix-based configs
- Adds a dev shell for contributors using Nix

## Usage

```nix
# flake.nix
inputs.spank.url = "github:taigrr/spank";

# home-manager config
imports = [ inputs.spank.homeManagerModules.default ];

programs.spank.enable = true;
```

The module exposes options for `mode`, `fast`, `minAmplitude`, `cooldown`, `volumeScaling`, and `customPath`.