### PR TITLE
fix: apply stdio set command (amplitude/cooldown) in detection loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -427,10 +427,10 @@ func listenForSlaps(ctx context.Context, pack *soundPack, accelRing *shm.RingBuf
 		}
 		lastEventTime = ev.Time
 
-		if time.Since(lastYell) <= tuning.cooldown {
+		if time.Since(lastYell) <= time.Duration(cooldownMs)*time.Millisecond {
 			continue
 		}
-		if ev.Amplitude < tuning.minAmplitude {
+		if ev.Amplitude < minAmplitude {
 			continue
 		}
 


### PR DESCRIPTION
Bug: In stdio mode, the set command updates the global minAmplitude and cooldownMs, but the detection loop in listenForSlaps still used the initial tuning struct. So changing amplitude or cooldown via stdin had no effect until restart.

Fix: Use the global minAmplitude and time.Duration(cooldownMs)*time.Millisecond in the loop instead of tuning.minAmplitude and tuning.cooldown, so live updates from the set command take effect immediately.