### PR TITLE
docs: confirm M1 Pro compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Uses the Apple Silicon accelerometer (Bosch BMI286 IMU via IOKit HID) to detect 
 - `sudo` (for IOKit HID accelerometer access)
 - Go 1.26+ (if building from source)
 
+## Confirmed Working Hardware
+
+| Chip | Model | macOS | Accelerometer | Status |
+|------|-------|-------|---------------|--------|
+| Apple M1 Pro | MacBookPro18,1 (16", 2021) | 15.2 (24C101) | Apple HID Accelerometer (SPI, VendorID: 1452, ProductID: 835) | Builds and runs |
+
 ## Install
 
 Download from the [latest release](https://github.com/taigrr/spank/releases/latest).


### PR DESCRIPTION
## Summary

The README currently lists **M2+** as a requirement, but spank builds and runs successfully on **Apple M1 Pro**. This PR adds a "Confirmed Working Hardware" table to document tested configurations beyond M2.

## Machine Details

| Field | Value |
|-------|-------|
| Chip | Apple M1 Pro (10-core CPU, 16-core GPU) |
| Model | MacBookPro18,1 (16-inch, 2021) |
| Memory | 16 GB |
| macOS | 15.2 Sequoia (build 24C101) |
| Go | 1.26.0 (auto-toolchained from 1.25.6) |

## Accelerometer Info (via `ioreg`)

| Field | Value |
|-------|-------|
| InterfaceName | `Accelerometer` |
| Transport | SPI |
| Manufacturer | Apple Inc. |
| VendorID | 1452 |
| ProductID | 835 |
| HID Class | `AppleHIDTransportHIDDevice` |
| Serial | FM7151306BWNX0QAM+RMZ |

The accelerometer is exposed as an HID device on the SPI bus, bundled with the internal keyboard/trackpad — same IOKit HID path that spank uses for sensor access.

## What was tested

- `go build` compiles cleanly
- Binary runs with `sudo` and detects the accelerometer hardware
- Help output and all flags work as documented

This suggests the M2+ requirement could be relaxed to **M1 Pro+** (and possibly other M1 variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)