### PR TITLE
fix: broken star history chart in the READMEs

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -223,7 +223,7 @@ sudo launchctl unload /Library/LaunchDaemons/com.taigrr.spank.plist
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=taigrr/spank&type=date&legend=top-left)](https://www.star-history.com/#taigrr/spank&type=date&legend=top-left)
+[![Star History Chart](https://afterglow.watch/svg?repos=taigrr/spank&type=date&legend=top-left)](https://afterglow.watch)
 
 ## 致谢
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ sudo launchctl unload /Library/LaunchDaemons/com.taigrr.spank.plist
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=taigrr/spank&type=date&legend=top-left)](https://www.star-history.com/#taigrr/spank&type=date&legend=top-left)
+[![Star History Chart](https://afterglow.watch/svg?repos=taigrr/spank&type=date&legend=top-left)](https://afterglow.watch)
 
 ## Credits
 


### PR DESCRIPTION
The star history chart at the bottom of both READMEs has been a broken image since GitHub removed the stargazer endpoints at the end of June; api.star-history.com 404s the URL today.

This points the chart at afterglow.watch, which answers the same URL shape (type=date and the legend param included), and retargets the anchor since the old chart page is dead too. Same edit in README-zh.md. I run the site: daily snapshots of the public star count, every reading kept; spank has been measured since July 30, so the chart carries real line from that date.

Free, no token. Deleting the embed is an equally valid fix and I'll close this happily if you'd rather. Opting out of tracking entirely is on the site.